### PR TITLE
Fix missing future dataframe combinations

### DIFF
--- a/NHiTS_5August.ipynb
+++ b/NHiTS_5August.ipynb
@@ -1,4 +1,91 @@
-{
+# Now make predictions using the correctly formatted future dataframe
+print("Making predictions...")
+try:
+    forecasts = fcst.predict(futr_df=future_df_with_trend)
+    print("✅ Prediction successful!")
+    print(f"Forecasts shape: {forecasts.shape}")
+    print(f"Forecasts columns: {list(forecasts.columns)}")
+    print("\nFirst few forecast rows:")
+    print(forecasts.head())
+except Exception as e:
+    print(f"❌ Prediction failed: {e}")
+    print("\nLet's check if there are still missing combinations...")
+    
+    # Use the get_missing_future method to identify what's missing
+    try:
+        missing = fcst.get_missing_future(future_df_with_trend, df_train)
+        if len(missing) > 0:
+            print(f"Missing combinations: {len(missing)}")
+            print(missing.head(10))
+        else:
+            print("No missing combinations found.")
+    except Exception as e2:
+        print(f"Error checking missing combinations: {e2}")# Now we need to add the 'trend' exogenous variable to the future dataframe
+# We'll merge the trend values from our test data
+print("Adding trend values to future dataframe...")
+
+# Create a mapping of unique_id and ds to trend values from the original test data
+trend_mapping = df_test[['unique_id', 'ds', 'trend']].copy()
+print(f"Trend mapping shape: {trend_mapping.shape}")
+
+# Merge the trend values into the future dataframe
+future_df_with_trend = future_df.merge(
+    trend_mapping, 
+    on=['unique_id', 'ds'], 
+    how='left'
+)
+
+print(f"Future dataframe with trend shape: {future_df_with_trend.shape}")
+print("\nChecking for missing trend values:")
+missing_trend = future_df_with_trend['trend'].isna().sum()
+print(f"Missing trend values: {missing_trend}")
+
+if missing_trend > 0:
+    print("Rows with missing trend values:")
+    print(future_df_with_trend[future_df_with_trend['trend'].isna()][['unique_id', 'ds']])
+
+print("\nFinal future dataframe:")
+print(future_df_with_trend.head())
+print(f"Columns: {list(future_df_with_trend.columns)}")# Use the make_future_dataframe method to create the correct future dataframe
+# This ensures all required ID-timestamp combinations are included
+future_df = fcst.make_future_dataframe(df_train)
+print("Future dataframe shape:", future_df.shape)
+print("Future dataframe columns:", list(future_df.columns))
+print("\nFirst few rows of future_df:")
+print(future_df.head())
+
+# Check the date range in future_df
+print(f"\nFuture dataframe date range: {future_df['ds'].min()} to {future_df['ds'].max()}")
+print(f"Number of unique IDs in future_df: {future_df['unique_id'].nunique()}")
+print(f"Unique IDs: {sorted(future_df['unique_id'].unique())}")# Let's first check what combinations are expected vs what we have
+print("Unique IDs in training data:", sorted(df_train['unique_id'].unique()))
+print("Unique IDs in test data:", sorted(df_test['unique_id'].unique()))
+print("\nTraining data shape:", df_train.shape)
+print("Test data shape:", df_test.shape)
+
+# Check if all regions have data for all test periods
+test_periods = df_test['ds'].unique()
+test_regions = df_test['unique_id'].unique()
+print(f"\nTest periods: {len(test_periods)} periods")
+print(f"Test regions: {len(test_regions)} regions")
+print(f"Expected combinations: {len(test_periods) * len(test_regions)}")
+print(f"Actual test data rows: {len(df_test)}")
+
+# Check for missing combinations
+missing_combinations = []
+for region in df_train['unique_id'].unique():
+    for period in test_periods:
+        if not ((df_test['unique_id'] == region) & (df_test['ds'] == period)).any():
+            missing_combinations.append((region, period))
+
+if missing_combinations:
+    print(f"\nMissing combinations: {len(missing_combinations)}")
+    for region, period in missing_combinations[:10]:  # Show first 10
+        print(f"  {region} - {period}")
+    if len(missing_combinations) > 10:
+        print(f"  ... and {len(missing_combinations) - 10} more")
+else:
+    print("\nNo missing combinations found!"){
  "cells": [
   {
    "cell_type": "code",
@@ -430,7 +517,16 @@
     }
    ],
    "source": [
-    "forecasts = fcst.predict(futr_df=df_test)"
+    "# FIXED: Use make_future_dataframe to ensure all required ID-timestamp combinations
+# Original error was due to missing combinations in futr_df
+future_df = fcst.make_future_dataframe(df_train)
+
+# Add the trend exogenous variable from test data
+trend_mapping = df_test[['unique_id', 'ds', 'trend']].copy()
+future_df_with_trend = future_df.merge(trend_mapping, on=['unique_id', 'ds'], how='left')
+
+# Make predictions with the correctly formatted future dataframe
+forecasts = fcst.predict(futr_df=future_df_with_trend)"
    ]
   }
  ],


### PR DESCRIPTION
Fix `ValueError` in `fcst.predict()` by correctly preparing `futr_df` with all expected ID-timestamp combinations and merging exogenous variables.

The `NeuralForecast` model requires a `futr_df` that contains all combinations of unique IDs and timestamps for the entire forecast horizon. The previous approach directly used `df_test`, which lacked these complete combinations, leading to the `ValueError`. This PR resolves the issue by using `fcst.make_future_dataframe()` to generate the complete future dataframe and then explicitly merges the `trend` exogenous variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-09fa90df-542c-4bf3-8b45-34c30ff90028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09fa90df-542c-4bf3-8b45-34c30ff90028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>